### PR TITLE
Add ARN support for job queue and job definition

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const handleAwsTrigger = records => {
 const validateAndExtractRequest = request => {
   const req = {};
   for (const key of ['jobDefinition', 'jobQueue']) {
-    req[key] = validateString(key, request[key], validateString.AWS_NAME);
+    req[key] = validateString(key, request[key], validateString.AWS_NAME_ARN);
   }
   req.jobName = generateJobName(request);
 
@@ -83,6 +83,7 @@ const validateString = (name, str, pattern = null) => {
   return str;
 };
 validateString.AWS_NAME = /^[-_a-zA-Z0-9]+$/;
+validateString.AWS_NAME_ARN = /(^arn:([^:\n]*):([^:\n]*):([^:\n]*):([^:\n]*):(([^:\/\n]*)[:\/])?(.*)$)|(^[-_a-zA-Z0-9]+$)/
 validateString.SHELL_VARIABLE = /^[_.a-zA-Z][_.a-zA-Z0-9]+$/;
 
 const validatePattern = (pattern, str) => {

--- a/test/aws-batch-trigger-validate.test.js
+++ b/test/aws-batch-trigger-validate.test.js
@@ -91,6 +91,20 @@ test('validate string support empty string', t => {
   t.deepEqual(validateString('toto', ''), '');
 });
 
+test('validate string', t => {
+  t.deepEqual(validateString('toto', 'tata', validateString.AWS_NAME_ARN), 'tata');
+});
+
+test('validate ARN string with version and /', t => {
+  const arn = 'arn:aws:batch:eu-west-1:005166266199:toto/toto:1';
+  t.deepEqual(validateString('toto', arn, validateString.AWS_NAME_ARN), arn);
+});
+
+test('validate ARN string', t => {
+  const arn = 'arn:aws:batch:eu-west-1:005166266199:toto';
+  t.deepEqual(validateString('toto', arn, validateString.AWS_NAME_ARN), arn);
+});
+
 test('validate string support check str pattern', t => {
   t.throws(
     () => validateString('toto', ' space in it', validateString.AWS_NAME),
@@ -99,6 +113,18 @@ test('validate string support check str pattern', t => {
   t.throws(
     () => validateString('toto', 'DASH-in-it', validateString.SHELL_VARIABLE),
     `toto does not comply with pattern '${validateString.SHELL_VARIABLE}'`
+  );
+  t.throws(
+    () => validateString('toto', '878&*&*specialchar', validateString.AWS_NAME),
+    `toto does not comply with pattern '${validateString.AWS_NAME}'`
+  );
+  t.throws(
+    () => validateString('toto', ' space in it', validateString.AWS_NAME_ARN),
+    `toto does not comply with pattern '${validateString.AWS_NAME_ARN}'`
+  );
+  t.throws(
+    () => validateString('toto', '878&*&*specialchar', validateString.AWS_NAME_ARN),
+    `toto does not comply with pattern '${validateString.AWS_NAME_ARN}'`
   );
 });
 


### PR DESCRIPTION
Hi,

I just update regex to accept name or ARN.
According to the AWS documentation, we can "specify either the name or the Amazon Resource Name (ARN)" of the queue or definition.